### PR TITLE
Cache reflection results to drastically improve performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.ialistannen</groupId>
     <artifactId>MiniNBT</artifactId>
-    <version>1.0.2-cache-patch</version>
+    <version>1.0.3</version>
     <packaging>jar</packaging>
 
     <name>MiniNBT</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.ialistannen</groupId>
     <artifactId>MiniNBT</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.2-cache-patch</version>
     <packaging>jar</packaging>
 
     <name>MiniNBT</name>
@@ -14,6 +14,14 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
+
+    <distributionManagement>
+        <repository>
+            <id>internal.repo</id>
+            <name>Build repo</name>
+            <url>file://${basedir}/../maven-repo</url>
+        </repository>
+    </distributionManagement>
 
     <build>
         <defaultGoal>clean package</defaultGoal>


### PR DESCRIPTION
MiniNBT was using 50% of CPU time on a server that was running a plugin of mine because all of the reflection queries are being re-ran so much. this is a simple but tedious patch to cache all reflection results so you only ever find a class/method/field/constructor once. ever.

if it's an issue i can remove the distributionManagement bit from the pom.xml, but that's what i've been using to publish to rayzr.dev/repo -- figured i might as well leave it there because anybody can use it then (just gotta make a sibling folder called maven-repo).

tests pass and my plugins work fine on this version so I'd consider that a good sign.