### PR TITLE
Add support for loading from files/streams

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.ialistannen</groupId>
     <artifactId>MiniNBT</artifactId>
-    <version>1.0.4</version>
+    <version>1.0.4-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>MiniNBT</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.ialistannen</groupId>
     <artifactId>MiniNBT</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
     <packaging>jar</packaging>
 
     <name>MiniNBT</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.ialistannen</groupId>
     <artifactId>MiniNBT</artifactId>
-    <version>1.0.4-SNAPSHOT</version>
+    <version>1.0.4-add-file-support</version>
     <packaging>jar</packaging>
 
     <name>MiniNBT</name>

--- a/src/main/java/me/ialistannen/mininbt/NBTWrappers.java
+++ b/src/main/java/me/ialistannen/mininbt/NBTWrappers.java
@@ -168,7 +168,7 @@ public class NBTWrappers {
     private static final FluentType<?> NBT_BASE = ClassLookup.NMS
         .forName("NBTBase").getOrThrow();
 
-    private static final FluentType<?> NBT_TAG_COMPOUND_CLASS = ClassLookup.NMS
+    public static final FluentType<?> NBT_TAG_COMPOUND_CLASS = ClassLookup.NMS
         .forName("NBTTagCompound").getOrThrow();
 
     private static final FluentConstructor<?> NBT_TAG_COMPOUND_CONSTRUCTOR = NBT_TAG_COMPOUND_CLASS

--- a/src/main/java/me/ialistannen/mininbt/StreamNBTUtil.java
+++ b/src/main/java/me/ialistannen/mininbt/StreamNBTUtil.java
@@ -17,7 +17,7 @@ public class StreamNBTUtil {
       .findMethod()
       .withParameters(InputStream.class)
       .withReturnType(NBTTagCompound.NBT_TAG_COMPOUND_CLASS.getUnderlying())
-      .findSingle()
+      .findFirst()
       .getOrThrow();
 
   private static final FluentReflection.FluentMethod WRITE_STREAM = NBT_COMPRESSED_STREAM_TOOLS
@@ -26,13 +26,13 @@ public class StreamNBTUtil {
           NBTTagCompound.NBT_TAG_COMPOUND_CLASS.getUnderlying(),
           OutputStream.class
       )
-      .findSingle()
+      .findFirst()
       .getOrThrow();
 
   // thrown by the underlying reflected method
   @SuppressWarnings("RedundantThrows")
   public static NBTTagCompound fromStream(InputStream inputStream) throws IOException {
-    Object nbtObject = FROM_STREAM.invokeStatic(inputStream);
+    Object nbtObject = FROM_STREAM.invokeStatic(inputStream).getOrThrow();
 
     return (NBTTagCompound) NBTTagCompound.fromNBT(nbtObject);
   }
@@ -40,6 +40,6 @@ public class StreamNBTUtil {
   // thrown by the underlying reflected method
   @SuppressWarnings("RedundantThrows")
   public static void writeToStream(NBTTagCompound compound, OutputStream outputStream) throws IOException {
-    Object nbtObject = FROM_STREAM.invokeStatic(compound.toNBT(), outputStream);
+    WRITE_STREAM.invokeStatic(compound.toNBT(), outputStream);
   }
 }

--- a/src/main/java/me/ialistannen/mininbt/StreamNBTUtil.java
+++ b/src/main/java/me/ialistannen/mininbt/StreamNBTUtil.java
@@ -1,0 +1,45 @@
+package me.ialistannen.mininbt;
+
+import me.ialistannen.mininbt.NBTWrappers.NBTTagCompound;
+import me.ialistannen.mininbt.reflection.BukkitReflection;
+import me.ialistannen.mininbt.reflection.FluentReflection;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public class StreamNBTUtil {
+  private static final FluentReflection.FluentType<?> NBT_COMPRESSED_STREAM_TOOLS = BukkitReflection.ClassLookup.NMS
+      .forName("NBTCompressedStreamTools")
+      .getOrThrow();
+
+  private static final FluentReflection.FluentMethod FROM_STREAM = NBT_COMPRESSED_STREAM_TOOLS
+      .findMethod()
+      .withParameters(InputStream.class)
+      .withReturnType(NBTTagCompound.NBT_TAG_COMPOUND_CLASS.getUnderlying())
+      .findSingle()
+      .getOrThrow();
+
+  private static final FluentReflection.FluentMethod WRITE_STREAM = NBT_COMPRESSED_STREAM_TOOLS
+      .findMethod()
+      .withParameters(
+          NBTTagCompound.NBT_TAG_COMPOUND_CLASS.getUnderlying(),
+          OutputStream.class
+      )
+      .findSingle()
+      .getOrThrow();
+
+  // thrown by the underlying reflected method
+  @SuppressWarnings("RedundantThrows")
+  public static NBTTagCompound fromStream(InputStream inputStream) throws IOException {
+    Object nbtObject = FROM_STREAM.invokeStatic(inputStream);
+
+    return (NBTTagCompound) NBTTagCompound.fromNBT(nbtObject);
+  }
+
+  // thrown by the underlying reflected method
+  @SuppressWarnings("RedundantThrows")
+  public static void writeToStream(NBTTagCompound compound, OutputStream outputStream) throws IOException {
+    Object nbtObject = FROM_STREAM.invokeStatic(compound.toNBT(), outputStream);
+  }
+}


### PR DESCRIPTION
this adds the ability to read & write NBTTagCompounds from files/streams

technically it only has methods for dealing with streams, because making a stream from a file is as simple as `new FileInputStream(...)` or whatever, but if you'd prefer I add helpers for reading/writing actual `File` objects then I can do that too